### PR TITLE
SEARCH-554    Model Tracker does not delete in-memory models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <artifactId>alfresco-solr4-parent</artifactId>
     <name>Alfresco Solr 4</name>
     <packaging>pom</packaging>
-    <version>6.2-SNAPSHOT</version>
+    <version>6.5-SNAPSHOT</version>
 
     <modules>
         <module>solr4</module>

--- a/solr4-distribution/pom.xml
+++ b/solr4-distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>alfresco-solr4-parent</artifactId>
         <groupId>org.alfresco</groupId>
-        <version>6.2-SNAPSHOT</version>
+        <version>6.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/solr4/pom.xml
+++ b/solr4/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-solr4-parent</artifactId>
-        <version>6.2-SNAPSHOT</version>
+        <version>6.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/solr4/source/java/org/alfresco/solr/AlfrescoSolrDataModel.java
+++ b/solr4/source/java/org/alfresco/solr/AlfrescoSolrDataModel.java
@@ -1414,6 +1414,13 @@ public class AlfrescoSolrDataModel implements QueryConstants
        
     }
 
+    public boolean removeModel(QName modelQName)
+    {
+    	modelErrors.remove(modelQName);
+    	dictionaryDAO.removeModel(modelQName); 
+    	return true;
+    }
+
     
     private Set<String> validateModel(M2Model model)
     {


### PR DESCRIPTION
 - MNT-17627 When a model created in Model Manager has a text property and the search option is set to “List of values – whole match” the search results are being tokenized.