### PR TITLE
[ MNT-19290 ] Solr4 bootstrap failure (backport from ASS)

### DIFF
--- a/solr4/source/java/org/alfresco/solr/servlet/Solr4X509ServletFilter.java
+++ b/solr4/source/java/org/alfresco/solr/servlet/Solr4X509ServletFilter.java
@@ -32,11 +32,14 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.solr.core.SolrResourceLoader;
 import org.alfresco.web.scripts.servlet.X509ServletFilterBase;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * The Solr4X509ServletFilter implements the checkEnforce method of the X509ServletFilterBase.
@@ -50,6 +53,24 @@ public class Solr4X509ServletFilter extends X509ServletFilterBase
     private static final String SECURE_COMMS = "alfresco.secureComms";
 
     private static Log logger = LogFactory.getLog(Solr4X509ServletFilter.class);
+
+    static final int NOT_FOUND_HTTPS_PORT_NUMBER = -1;
+
+    private Function<ObjectName, Integer> extractPortNumber = name ->
+    {
+        try
+        {
+            return ofNullable(mxServer().getAttribute(name, "Port"))
+                    .map(Number.class::cast)
+                    .map(Number::intValue)
+                    .orElse(NOT_FOUND_HTTPS_PORT_NUMBER);
+        }
+        catch(final Exception exception)
+        {
+            logger.error("Error getting https port from MBean " + name, exception);
+            return NOT_FOUND_HTTPS_PORT_NUMBER;
+        }
+    };
 
     @Override
     protected boolean checkEnforce(ServletContext context) throws IOException
@@ -212,42 +233,34 @@ public class Solr4X509ServletFilter extends X509ServletFilterBase
         }
     }
 
-    private int getHttpsPort()
+    int getHttpsPort()
+    {
+        return connectorMBeanName().map(extractPortNumber).orElse(NOT_FOUND_HTTPS_PORT_NUMBER);
+    }
+
+    Optional<ObjectName> connectorMBeanName()
     {
         try
         {
-            MBeanServer mBeanServer = MBeanServerFactory.findMBeanServer(null).get(0);
-            QueryExp query = Query.eq(Query.attr("Scheme"), Query.value("https"));
-            Set<ObjectName> objectNames = mBeanServer.queryNames(null, query);
-
-            if (objectNames != null && objectNames.size() > 0)
-            {
-                for (ObjectName objectName : objectNames)
-                {
-                    String name = objectName.toString();
-                    if (name.indexOf("port=") > -1)
-                    {
-                        String[] parts = name.split("port=");
-                        String port = parts[1];
-                        try
-                        {
-                            int portNum = Integer.parseInt(port);
-                            return portNum;
-                        }
-                        catch (NumberFormatException e)
-                        {
-                            logger.error("Error parsing https port:" + port);
-                            return -1;
-                        }
-                    }
-                }
-            }
+            final QueryExp query = Query.eq(Query.attr("Scheme"), Query.value("https"));
+            final Set<ObjectName> connectors = mxServer().queryNames(null, query);
+            return connectors
+                    .stream()
+                    .findFirst();
         }
-        catch(Throwable t)
+        catch (final Exception exception)
         {
-            logger.error("Error getting https port:", t);
+            logger.error("Error getting the Connector MBean.", exception);
+            return Optional.empty();
         }
+    }
 
-        return -1;
+    MBeanServer mxServer()
+    {
+        return ofNullable((MBeanServerFactory.findMBeanServer(null)))
+                .filter(servers -> !servers.isEmpty())
+                .map(Collection::iterator)
+                .map(Iterator::next)
+                .orElseThrow(NoSuchElementException::new);
     }
 }

--- a/solr4/source/test-java/org/alfresco/solr/servlet/Solr4X509ServletFilterTest.java
+++ b/solr4/source/test-java/org/alfresco/solr/servlet/Solr4X509ServletFilterTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2005-2014 Alfresco Software Limited.
+ *
+ * This file is part of Alfresco
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.alfresco.solr.servlet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test cases for {@link Solr4X509ServletFilter}.
+ */
+public class Solr4X509ServletFilterTest
+{
+
+    public interface TestConnectorMBean
+    {
+
+        String getScheme();
+
+        void setScheme(String scheme);
+
+        int getPort();
+
+        void setPort(int port);
+    }
+
+    private class TestConnector implements TestConnectorMBean
+    {
+
+        private int port;
+        private String scheme;
+
+        TestConnector(final int port, final String scheme)
+        {
+            this.port = port;
+            this.scheme = scheme;
+        }
+
+        @Override
+        public String getScheme()
+        {
+            return scheme;
+        }
+
+        @Override
+        public void setScheme(final String scheme)
+        {
+            this.scheme = scheme;
+        }
+
+        @Override
+        public int getPort()
+        {
+            return port;
+        }
+
+        @Override
+        public void setPort(final int port)
+        {
+            this.port = port;
+        }
+    }
+
+    private Solr4X509ServletFilter cut;
+    private MBeanServer mxServer;
+
+    @Before
+    public void setUp()
+    {
+        cut = new Solr4X509ServletFilter();
+        try
+        {
+            mxServer = cut.mxServer();
+        }
+        catch (final NoSuchElementException exception)
+        {
+            mxServer = MBeanServerFactory.createMBeanServer("A_DOMAIN");
+        }
+    }
+
+    @After
+    public void tearDown()
+    {
+        try
+        {
+            cut.mxServer().unregisterMBean(cut.connectorMBeanName().get());
+        }
+        catch (final Exception exception) {
+            // Ignore
+        }
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void mxServerNotFound()
+    {
+        MBeanServerFactory.releaseMBeanServer(mxServer);
+        cut.mxServer();
+    }
+
+    @Test
+    public void noAvailableConnectors()
+    {
+        assertFalse(cut.connectorMBeanName().isPresent());
+        assertEquals(Solr4X509ServletFilter.NOT_FOUND_HTTPS_PORT_NUMBER, cut.getHttpsPort());
+    }
+
+    @Test
+    public void oneAvailableHttpsConnector() throws Exception
+    {
+        final int expectedPort = 8443;
+
+        registerConnector("https", expectedPort);
+
+        assertEquals(expectedPort, cut.getHttpsPort());
+    }
+
+    @Test
+    public void httpAndHttpsConnectors() throws Exception
+    {
+        final int expectedPort = 8443;
+
+        registerConnector("http", 80);
+        registerConnector("https", expectedPort);
+
+        assertEquals(expectedPort, cut.getHttpsPort());
+    }
+
+    @Test
+    public void cannotGetHttpsPort() throws Exception
+    {
+        registerTouchyHttpsConnector();
+
+        assertEquals(Solr4X509ServletFilter.NOT_FOUND_HTTPS_PORT_NUMBER, cut.getHttpsPort());
+    }
+
+    @Test
+    public void onlyHttpConnector() throws Exception
+    {
+        registerConnector("http", 8080);
+
+        assertFalse(cut.connectorMBeanName().isPresent());
+        assertEquals(Solr4X509ServletFilter.NOT_FOUND_HTTPS_PORT_NUMBER, cut.getHttpsPort());
+    }
+
+    /**
+     * Registers a Connector MBean with the given scheme and port.
+     *
+     * @param scheme the scheme.
+     * @param port the port number.
+     * @throws Exception hopefully never, otherwise the test fails.
+     */
+    private void registerConnector(final String scheme, final int port) throws Exception
+    {
+        final ObjectName name = new ObjectName("A_DOMAIN", "created",  String.valueOf(System.nanoTime()));
+        cut.mxServer().registerMBean(new TestConnector(port, scheme), name);
+    }
+
+    /**
+     * Registers a HTTPS Connector MBean which throws an exception when the getPort method is called.
+     *
+     * @throws Exception hopefully never, otherwise the test fails.
+     */
+    private void registerTouchyHttpsConnector() throws Exception
+    {
+        final ObjectName name = new ObjectName("A_DOMAIN", "created",  String.valueOf(System.nanoTime()));
+        cut.mxServer().registerMBean(
+                new TestConnector(0, "https")
+                {
+                    @Override
+                    public int getPort()
+                    {
+                        throw new RuntimeException("Don't ask me the port number!");
+                    }
+                }, name);
+    }
+}


### PR DESCRIPTION
The PR contains the changes already applied to ASS:

- Correct JMX API usage for retrieving MBeans attributes (HTTPS Connector in this case) 
- Unit test  